### PR TITLE
Add GitHub action to make CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, zip, xml
+          coverage: none
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Run test suite
+        run: vendor/bin/phpunit tests/

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/DownloadTest.php
+++ b/tests/DownloadTest.php
@@ -11,7 +11,7 @@ class DownloadTest extends TestCase
     /** @var CurlDownloader */
     protected $client;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->client = new CurlDownloader(new Client());
     }


### PR DESCRIPTION
# Changed log

- Integrating the GitHub action to make CI tests.
- Adding the `PHPUnit ^8.0` version for `PHP 7.2+` version tests. Otherwise it will present the following error message when running the `composer update` command:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - phpunit/phpunit[7.0.0, ..., 7.5.20] require php ^7.1 -> your php version (8.0.28) does not satisfy that requirement.
    - Root composer.json requires phpunit/phpunit ^7.0 -> satisfiable by phpunit/phpunit[7.0.0, ..., 7.5.20].

```

- Adding the `void` type hint for the `setUp` method to be compatible with `PHPUnit 8.x` version. Otherwise it will present the following error message when running the `vendor/bin/phpunit` command:

```
PHP Fatal error:  Declaration of CurlDownloader\Tests\DownloadTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void
```