### PR TITLE
Added an option to the download() method for a progress callback function. 

### DIFF
--- a/src/CurlDownloader.php
+++ b/src/CurlDownloader.php
@@ -60,8 +60,16 @@ class CurlDownloader
 
 	    if ($progressCallback) {
             $options[CURLOPT_NOPROGRESS] = false;
-            $options[CURLOPT_PROGRESSFUNCTION] = $progressCallback;
+
+            if(defined('CURLOPT_XFERINFOFUNCTION')) { // PHP 8.2
+                $options[CURLOPT_XFERINFOFUNCTION] = $progressCallback;
+            }
+            else {
+				$options[CURLOPT_PROGRESSFUNCTION] = $progressCallback;
+            }
 	    }
+
+
 
         $response = $this->client->request('GET', $url, [], [], $options);
 

--- a/src/CurlDownloader.php
+++ b/src/CurlDownloader.php
@@ -19,7 +19,7 @@ class CurlDownloader
 
     protected function createTempFile()
     {
-        return tempnam(sys_get_temp_dir(), uniqid());
+        return tempnam(sys_get_temp_dir(), uniqid('', true));
     }
 
     protected function getPathFromUrl($url)
@@ -43,7 +43,7 @@ class CurlDownloader
      * @param $destination
      * @return \Curl\Response
      */
-    public function download($url, $destination)
+    public function download($url, $destination, $progressCallback = null)
     {
         $handler = new HeaderHandler();
 
@@ -52,11 +52,18 @@ class CurlDownloader
 
         $handle = fopen($temp_filename, 'w+');
 
-        $response = $this->client->request('GET', $url, [], [], [
+        $options = [
             CURLOPT_FILE => $handle,
             CURLOPT_HEADERFUNCTION => $handler->callback(),
             CURLOPT_TIMEOUT => $this->max_timeout
-        ]);
+	    ];
+
+	    if ($progressCallback) {
+            $options[CURLOPT_NOPROGRESS] = false;
+            $options[CURLOPT_PROGRESSFUNCTION] = $progressCallback;
+	    }
+
+        $response = $this->client->request('GET', $url, [], [], $options);
 
         // TODO: refactor this whole filename logic into its own class
         if ($response->info->http_code === 200) {
@@ -72,12 +79,12 @@ class CurlDownloader
 
                 // E.g: https://www.google.com/
                 if (empty($filename)) {
-                    $filename = 'index.' . ($extension_from_content_type ? $extension_from_content_type : 'html');
+                    $filename = 'index.' . ($extension_from_content_type ?: 'html');
                 } else {
 
                     // in case filename in url is like `videoplayback` with `content-type: video/mp4`
                     if (empty($extension_from_url) && $extension_from_content_type) {
-                        $filename = ($filename . '.' . $extension_from_content_type);
+                        $filename .= '.' . $extension_from_content_type;
                     }
                 }
             }

--- a/tests/DownloadTest.php
+++ b/tests/DownloadTest.php
@@ -44,6 +44,12 @@ class DownloadTest extends TestCase
 
 
         $this->assertFileExists('./e107-master.zip');
+
+        if(empty($GLOBALS['testProgress']))
+        {
+			$this->fail('Progress not found');
+        }
+
         $this->assertSame('100%', $GLOBALS['testProgress']);
 
         unlink('./e107-master.zip');

--- a/tests/DownloadTest.php
+++ b/tests/DownloadTest.php
@@ -11,6 +11,7 @@ class DownloadTest extends TestCase
     /** @var CurlDownloader */
     protected $client;
 
+
     protected function setUp(): void
     {
         $this->client = new CurlDownloader(new Client());
@@ -18,13 +19,34 @@ class DownloadTest extends TestCase
 
     public function test_download_directly()
     {
-        $this->client->download("https://demo.borland.com/testsite/downloads/Small.zip", function ($filename) {
+        $this->client->download("https://github.com/Athlon1600/php-curl-file-downloader/archive/refs/heads/master.zip", function ($filename) {
             return './' . $filename;
         });
 
-        $this->assertTrue(file_exists('./Small.zip'));
+        $this->assertFileExists('./php-curl-file-downloader-master.zip');
 
-        unlink('./Small.zip');
+        unlink('./php-curl-file-downloader-master.zip');
+    }
+
+	public function test_download_directly_with_progress_callback()
+    {
+        $callBack = function($resource, $DownloadSize, $Downloaded, $UploadSize, $Uploaded){
+
+            if ($DownloadSize > 0){
+                    $progress = round($Downloaded / $DownloadSize  * 100) . '%';
+                    $GLOBALS['testProgress'] = $progress;
+            }
+		};
+
+        $this->client->download("https://github.com/e107inc/e107/archive/refs/heads/master.zip", function ($filename) {
+            return './' . $filename;
+        }, $callBack );
+
+
+        $this->assertFileExists('./e107-master.zip');
+        $this->assertSame('100%', $GLOBALS['testProgress']);
+
+        unlink('./e107-master.zip');
     }
 
     public function test_download_content_disposition()


### PR DESCRIPTION
Hi @Athlon1600 

Thanks for sharing your curl-file-downloader! 

I added an option to the `download()` method for a progress callback function  (very useful with large files) 
Included a test also (it requires a larger file download - feel free to change the URL). 

Also, please note that all tests were failing in my local environment (PHPStorm, PHP 8.2.12, Windows 11) prior to any of my changes. 
 (URLs timing out, also confirmed manually in browser) 

I modified the URL of `test_download_directly()` to at least have one working test example. 

Hope you find this addition useful! 

Thanks!
Cameron



